### PR TITLE
Rename get_showcase_wysiwyg_editor 

### DIFF
--- a/ckanext/showcase/logic/helpers.py
+++ b/ckanext/showcase/logic/helpers.py
@@ -35,5 +35,5 @@ def get_site_statistics():
     return stats
 
 
-def get_wysiwyg_editor():
+def showcase_get_wysiwyg_editor():
     return tk.config.get('ckanext.showcase.editor', '')

--- a/ckanext/showcase/plugin/__init__.py
+++ b/ckanext/showcase/plugin/__init__.py
@@ -118,7 +118,8 @@ class ShowcasePlugin(
         return {
             'facet_remove_field': showcase_helpers.facet_remove_field,
             'get_site_statistics': showcase_helpers.get_site_statistics,
-            'get_wysiwyg_editor': showcase_helpers.get_wysiwyg_editor,
+            'showcase_get_wysiwyg_editor':
+                showcase_helpers.showcase_get_wysiwyg_editor,
         }
 
     # IFacets
@@ -167,7 +168,7 @@ class ShowcasePlugin(
                 context, {'showcase_id': pkg_dict['id']}))
 
         # Rendered notes
-        if showcase_helpers.get_wysiwyg_editor() == 'ckeditor':
+        if showcase_helpers.showcase_get_wysiwyg_editor() == 'ckeditor':
             pkg_dict[u'showcase_notes_formatted'] = pkg_dict['notes']
         else:
             pkg_dict[u'showcase_notes_formatted'] = \

--- a/ckanext/showcase/templates/showcase/new_package_form.html
+++ b/ckanext/showcase/templates/showcase/new_package_form.html
@@ -29,7 +29,7 @@
       {% endblock %}
 
       {% block package_basic_fields_description %}
-        {% set editor = h.get_wysiwyg_editor() %}
+        {% set editor = h.showcase_get_wysiwyg_editor() %}
         {% if editor == 'ckeditor' %}
           {% set _type = 'asset' if h.ckan_version().split('.')[1] | int >= 9 else 'resource'  %}
           {% snippet 'showcase/snippets/ckeditor_' ~ _type ~ '.html' %}

--- a/ckanext/showcase/templates/showcase/read.html
+++ b/ckanext/showcase/templates/showcase/read.html
@@ -2,7 +2,7 @@
 
 {% set pkg = pkg_dict or c.pkg_dict %}
 {% set name = pkg.title or pkg.name %}
-{% set editor = h.get_wysiwyg_editor() %}
+{% set editor = h.showcase_get_wysiwyg_editor() %}
 
 {% set ckan_29_or_higher = h.ckan_version().split('.')[1] | int >= 9 %}
 {% set showcase_read_route = 'showcase_blueprint.read' if ckan_29_or_higher else 'showcase_read' %}


### PR DESCRIPTION
Rename get_showcase_wysiwyg_editor to avoid name clashes with other extensions (like 'ckanext-pages')